### PR TITLE
fixes the related issue

### DIFF
--- a/src/ZoneServer/CreatureObject.cpp
+++ b/src/ZoneServer/CreatureObject.cpp
@@ -562,6 +562,7 @@ void CreatureObject::RemoveBuff(Buff* buff)
 
     //Perform any Final changes
     buff->FinalChanges();
+    buff->MarkForDeletion();
 }
 
 //================================================

--- a/src/ZoneServer/MissionManager.cpp
+++ b/src/ZoneServer/MissionManager.cpp
@@ -691,7 +691,7 @@ void MissionManager::missionFailed(PlayerObject* player, MissionObject* mission)
             //argh
             mission->setInProgress(false);
             player->RemoveBuff(timer);
-            SAFE_DELETE(timer);
+            player->CleanUpBuffs();
             mission->setEntertainingTimer(NULL);
         }
     }


### PR DESCRIPTION
tested by consecutively picking up new entertainer missions and failing them immediately by starting playing and then walking away.
I tried this with 5 missions and in the time of this there were 2 player saves.

Next I was able to successfully complete a mission. I can not get this to crash now :)
