### PR TITLE
Modified std::make_pair usage

### DIFF
--- a/src/ZoneServer/WorldManager.cpp
+++ b/src/ZoneServer/WorldManager.cpp
@@ -345,7 +345,7 @@ void WorldManager::handleObjectReady(shared_ptr<Object> object)
     {
         uint32 key = (uint32)region->getId();
 
-        mQTRegionMap.insert(std::make_pair<uint32, shared_ptr<QTRegion>>(key, region));
+        mQTRegionMap.insert(std::make_pair(key, region));
 
         mSpatialIndex->insertQTRegion(key,region->mPosition.x,region->mPosition.z,region->getWidth(),region->getHeight());
     }

--- a/src/ZoneServer/WorldManagerDataBaseHandlers.cpp
+++ b/src/ZoneServer/WorldManagerDataBaseHandlers.cpp
@@ -302,8 +302,7 @@ void WorldManager::_loadWorldObjects()
                     creatureSpawnRegion->mWidth =  result_set->getDouble(4);
                     creatureSpawnRegion->mLength  = result_set->getDouble(5);
 
-                    mCreatureSpawnRegionMap.insert(std::make_pair<uint64_t, std::shared_ptr<CreatureSpawnRegion>>
-                                                   (creatureSpawnRegion->mId, creatureSpawnRegion));
+                    mCreatureSpawnRegionMap.insert(std::make_pair(creatureSpawnRegion->mId, creatureSpawnRegion));
                 }
                 LOG_IF(INFO, result_set->rowsCount()) << "Loaded " << result_set->rowsCount() << " Creature Spawn Regions";
                 LOG_IF(INFO, !result_set->rowsCount()) << "No Creature Spawn Regions Loaded with ID: " << mZoneId;

--- a/src/ZoneServer/WorldManagerObjectHandlers.cpp
+++ b/src/ZoneServer/WorldManagerObjectHandlers.cpp
@@ -319,7 +319,7 @@ bool WorldManager::addObject(Object* object,bool manual)
         }
         auto region = std::shared_ptr<RegionObject>(tmp);
 
-        mRegionMap.insert(std::make_pair<uint32, shared_ptr<RegionObject>>(key,region));
+        mRegionMap.insert(std::make_pair(key,region));
 
         mSpatialIndex->InsertRegion(key,region->mPosition.x,region->mPosition.z,region->getWidth(),region->getHeight());
 
@@ -352,7 +352,7 @@ bool WorldManager::addObject(std::shared_ptr<Object> object, bool manual)
 
     auto region = dynamic_pointer_cast<RegionObject>(object);
 
-    mRegionMap.insert(std::make_pair<uint64 ,shared_ptr<RegionObject>>(key,region));
+    mRegionMap.insert(std::make_pair(key,region));
 
     mSpatialIndex->InsertRegion(key,region->mPosition.x,region->mPosition.z,region->getWidth(),region->getHeight());
 


### PR DESCRIPTION
The implementation of make_pair is such that it's template parameters can be automatically detected based on the arguments passed to it, in fact adding the template parameters is only supported on windows platforms. On unix this will cause issues with name resolution which causes the compiler to error out.
